### PR TITLE
Fix: Stop Double-Counting Balances When Creating Orders

### DIFF
--- a/packages/deeptrade-core/sources/order.move
+++ b/packages/deeptrade-core/sources/order.move
@@ -24,6 +24,7 @@ use deeptrade_core::helper::{
 use deeptrade_core::loyalty::LoyaltyProgram;
 use deeptrade_core::treasury::{Treasury, join_coverage_fee, deep_reserves, split_deep_reserves};
 use pyth::price_info::PriceInfoObject;
+use std::type_name;
 use std::u64;
 use sui::balance;
 use sui::clock::Clock;
@@ -53,6 +54,7 @@ const ENotSupportedSelfMatchingOption: u64 = 8;
 const EInvalidSuiPerDeep: u64 = 9;
 /// Error when the slippage is invalid (greater than 100% in billionths)
 const EInvalidSlippage: u64 = 10;
+const EInvalidInputCoinType: u64 = 11;
 
 // === Structs ===
 /// A plan for allocating DEEP tokens for an order's DeepBook fees.
@@ -62,6 +64,8 @@ const EInvalidSlippage: u64 = 10;
 public struct DeepPlan has copy, drop {
     /// Amount of DEEP to take from user's wallet
     from_user_wallet: u64,
+    /// Amount of DEEP to take from user's balance manager
+    from_balance_manager: u64,
     /// Amount of DEEP to take from treasury reserves
     from_deep_reserves: u64,
     /// Whether treasury DEEP reserves has enough DEEP to cover the order
@@ -843,6 +847,8 @@ public fun cancel_order_and_settle_fees<BaseAsset, QuoteAsset, UnsettledFeeCoinT
 /// - treasury_deep_reserves: Amount of DEEP available in treasury reserves
 /// - order_amount: Order amount in quote tokens (for bids) or base tokens (for asks)
 /// - sui_per_deep: Current DEEP/SUI price from reference pool
+/// - input_coin_is_sui: Whether the input coin is SUI
+/// - input_coin_is_deep: Whether the input coin is DEEP
 ///
 /// Returns a tuple with three structured plans:
 /// - DeepPlan: Coordinates DEEP coin sourcing from user wallet and treasury reserves
@@ -853,14 +859,19 @@ public(package) fun create_order_core(
     deep_required: u64,
     balance_manager_deep: u64,
     balance_manager_sui: u64,
-    balance_manager_input_coin: u64,
+    mut balance_manager_input_coin: u64,
     deep_in_wallet: u64,
     sui_in_wallet: u64,
     wallet_input_coin: u64,
     treasury_deep_reserves: u64,
     order_amount: u64,
     sui_per_deep: u64,
+    input_coin_is_sui: bool,
+    input_coin_is_deep: bool,
 ): (DeepPlan, CoverageFeePlan, InputCoinDepositPlan) {
+    // Sanity check: input coin cannot be flagged as both SUI and DEEP. Either one of them, or none
+    assert!(!(input_coin_is_sui && input_coin_is_deep), EInvalidInputCoinType);
+
     // Step 1: Determine DEEP requirements
     let deep_plan = get_deep_plan(
         is_pool_whitelisted,
@@ -870,6 +881,13 @@ public(package) fun create_order_core(
         treasury_deep_reserves,
     );
 
+    // If input coin is DEEP, `balance_manager_input_coin` and `balance_manager_deep` are the same balance amounts.
+    // So, if the `balance_manager_deep` is planned to be consumed by the DeepPlan, we need to decrease
+    // the `balance_manager_input_coin` correspondingly for further calculations of the InputCoinDepositPlan
+    if (input_coin_is_deep && deep_plan.from_balance_manager > 0) {
+        balance_manager_input_coin = balance_manager_input_coin - deep_plan.from_balance_manager;
+    };
+
     // Step 2: Determine coverage fee charging plan
     let coverage_fee_plan = get_coverage_fee_plan(
         deep_plan.from_deep_reserves,
@@ -878,6 +896,14 @@ public(package) fun create_order_core(
         sui_in_wallet,
         balance_manager_sui,
     );
+
+    // If input coin is SUI, `balance_manager_input_coin` and `balance_manager_sui` are the same balance amounts.
+    // So, if the `balance_manager_sui` is planned to be consumed by the CoverageFeePlan, we need to decrease
+    // the `balance_manager_input_coin` correspondingly for further calculations of the InputCoinDepositPlan
+    if (input_coin_is_sui && coverage_fee_plan.from_balance_manager > 0) {
+        balance_manager_input_coin =
+            balance_manager_input_coin - coverage_fee_plan.from_balance_manager;
+    };
 
     // Step 3: Determine input coin deposit plan
     let deposit_plan = get_input_coin_deposit_plan(
@@ -895,6 +921,7 @@ public(package) fun create_order_core(
 ///
 /// Returns a DeepPlan structure with the following information:
 /// - from_user_wallet: Amount of DEEP to take from user's wallet
+/// - from_balance_manager: Amount of DEEP to take from user's balance manager
 /// - from_deep_reserves: Amount of DEEP to take from treasury reserves
 /// - deep_reserves_cover_order: Whether treasury has enough DEEP to cover what's needed
 public(package) fun get_deep_plan(
@@ -908,6 +935,7 @@ public(package) fun get_deep_plan(
     if (is_pool_whitelisted) {
         return DeepPlan {
             from_user_wallet: 0,
+            from_balance_manager: 0,
             from_deep_reserves: 0,
             deep_reserves_cover_order: true,
         }
@@ -918,27 +946,32 @@ public(package) fun get_deep_plan(
 
     if (user_deep_total >= deep_required) {
         // User has enough DEEP
-        // Determine how much to take from wallet based on what's available
-        let from_wallet = if (balance_manager_deep >= deep_required) {
-            0 // Nothing needed from wallet if balance manager has enough
+        // Determine how much to take from wallet and balance manager based on what's available
+        let (from_wallet, from_balance_manager) = if (balance_manager_deep >= deep_required) {
+            // Nothing needed from wallet if balance manager has enough
+            (0, deep_required)
         } else {
-            deep_required - balance_manager_deep
+            // All from balance manager, remainder from wallet
+            (deep_required - balance_manager_deep, balance_manager_deep)
         };
 
         DeepPlan {
             from_user_wallet: from_wallet,
+            from_balance_manager: from_balance_manager,
             from_deep_reserves: 0,
             deep_reserves_cover_order: true,
         }
     } else {
         // Need treasury DEEP since user doesn't have enough
         let from_wallet = deep_in_wallet; // Take all from wallet
+        let from_balance_manager = balance_manager_deep; // Take all from balance manager
         let still_needed = deep_required - user_deep_total;
         let has_enough = treasury_deep_reserves >= still_needed;
 
         if (!has_enough) {
             return DeepPlan {
                 from_user_wallet: 0,
+                from_balance_manager: 0,
                 from_deep_reserves: 0,
                 deep_reserves_cover_order: false,
             }
@@ -946,6 +979,7 @@ public(package) fun get_deep_plan(
 
         DeepPlan {
             from_user_wallet: from_wallet,
+            from_balance_manager: from_balance_manager,
             from_deep_reserves: still_needed,
             deep_reserves_cover_order: true,
         }
@@ -1395,6 +1429,12 @@ public(package) fun prepare_order_execution<
         .get_pool_fee_config(pool)
         .max_deep_fee_coverage_discount_rate();
 
+    // Determine input coin type
+    let input_coin_is_sui = if (is_bid) type_name::get<QuoteToken>() == type_name::get<SUI>()
+    else type_name::get<BaseToken>() == type_name::get<SUI>();
+    let input_coin_is_deep = if (is_bid) type_name::get<QuoteToken>() == type_name::get<DEEP>()
+    else type_name::get<BaseToken>() == type_name::get<DEEP>();
+
     let (deep_plan, coverage_fee_plan, input_coin_deposit_plan) = create_order_core(
         is_pool_whitelisted,
         deep_required,
@@ -1407,6 +1447,8 @@ public(package) fun prepare_order_execution<
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     validate_fees_against_max(

--- a/packages/deeptrade-core/sources/order.move
+++ b/packages/deeptrade-core/sources/order.move
@@ -957,7 +957,7 @@ public(package) fun get_deep_plan(
 
         DeepPlan {
             from_user_wallet: from_wallet,
-            from_balance_manager: from_balance_manager,
+            from_balance_manager,
             from_deep_reserves: 0,
             deep_reserves_cover_order: true,
         }

--- a/packages/deeptrade-core/sources/order.move
+++ b/packages/deeptrade-core/sources/order.move
@@ -979,7 +979,7 @@ public(package) fun get_deep_plan(
 
         DeepPlan {
             from_user_wallet: from_wallet,
-            from_balance_manager: from_balance_manager,
+            from_balance_manager,
             from_deep_reserves: still_needed,
             deep_reserves_cover_order: true,
         }

--- a/packages/deeptrade-core/sources/order.move
+++ b/packages/deeptrade-core/sources/order.move
@@ -1883,11 +1883,13 @@ fun create_empty_protocol_fee_plan(user_covers_fee: bool): ProtocolFeePlan {
 public fun assert_deep_plan_eq(
     actual: DeepPlan,
     expected_from_wallet: u64,
+    expected_from_balance_manager: u64,
     expected_from_treasury: u64,
     expected_sufficient: bool,
 ) {
     use std::unit_test::assert_eq;
     assert_eq!(actual.from_user_wallet, expected_from_wallet);
+    assert_eq!(actual.from_balance_manager, expected_from_balance_manager);
     assert_eq!(actual.from_deep_reserves, expected_from_treasury);
     assert_eq!(actual.deep_reserves_cover_order, expected_sufficient);
 }

--- a/packages/deeptrade-core/tests/core/create_order_core.move
+++ b/packages/deeptrade-core/tests/core/create_order_core.move
@@ -34,6 +34,7 @@ public fun assert_order_plans_eq(
     input_coin_deposit_plan: InputCoinDepositPlan,
     // Expected values for DeepPlan
     expected_deep_from_wallet: u64,
+    expected_deep_from_balance_manager: u64,
     expected_deep_from_reserves: u64,
     expected_deep_sufficient: bool,
     // Expected values for CoverageFeePlan
@@ -48,6 +49,7 @@ public fun assert_order_plans_eq(
     assert_deep_plan_eq(
         deep_plan,
         expected_deep_from_wallet,
+        expected_deep_from_balance_manager,
         expected_deep_from_reserves,
         expected_deep_sufficient,
     );
@@ -122,7 +124,8 @@ public fun bid_order_sufficient_resources() {
         coverage_fee_plan,
         input_coin_deposit_plan,
         // DeepPlan expectations
-        deep_in_wallet, // expected_deep_from_wallet
+        deep_required - balance_manager_deep, // expected_deep_from_wallet
+        balance_manager_deep, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -205,6 +208,7 @@ public fun bid_order_with_treasury_deep() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         deep_from_wallet, // expected_deep_from_wallet
+        balance_manager_deep, // expected_deep_from_balance_manager
         deep_from_treasury, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -270,6 +274,7 @@ public fun bid_order_whitelisted_pool() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         0, // expected_deep_from_wallet
+        0, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -347,6 +352,7 @@ public fun bid_order_coverage_fee_from_both_sources() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         deep_in_wallet, // expected_deep_from_wallet
+        balance_manager_deep, // expected_deep_from_balance_manager
         deep_from_treasury, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -407,6 +413,7 @@ public fun bid_order_insufficient_deep_no_treasury() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         0, // expected_deep_from_wallet
+        0, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         false, // expected_deep_sufficient (not enough DEEP)
         // CoverageFeePlan expectations
@@ -467,6 +474,7 @@ public fun bid_order_quote_only_in_balance_manager() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         0, // expected_deep_from_wallet
+        balance_manager_deep, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -535,6 +543,7 @@ public fun bid_order_large_values() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         deep_in_wallet, // expected_deep_from_wallet
+        balance_manager_deep, // expected_deep_from_balance_manager
         deep_from_treasury, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -595,6 +604,7 @@ public fun bid_order_exact_resources() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         deep_required, // expected_deep_from_wallet
+        0, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -664,6 +674,7 @@ public fun ask_order_sufficient_resources() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         deep_from_wallet, // expected_deep_from_wallet
+        balance_manager_deep, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -729,6 +740,7 @@ public fun ask_order_whitelisted_pool() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         0, // expected_deep_from_wallet
+        0, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -789,6 +801,7 @@ public fun ask_order_insufficient_deep_and_base() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         0, // expected_deep_from_wallet
+        0, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         false, // expected_deep_sufficient (not enough DEEP)
         // CoverageFeePlan expectations
@@ -857,6 +870,7 @@ public fun ask_order_base_only_in_balance_manager() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         0, // expected_deep_from_wallet
+        balance_manager_deep, // expected_deep_from_balance_manager
         deep_from_treasury, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -926,6 +940,7 @@ public fun ask_order_large_values() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         deep_in_wallet, // expected_deep_from_wallet
+        0, // expected_deep_from_balance_manager
         deep_from_treasury, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -986,6 +1001,7 @@ public fun ask_order_exact_resources() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         deep_required, // expected_deep_from_wallet
+        0, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -1046,6 +1062,7 @@ public fun ask_order_complex_distribution() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         deep_in_wallet, // expected_deep_from_wallet
+        balance_manager_deep, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -1114,6 +1131,7 @@ public fun ask_order_insufficient_base() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         deep_in_wallet, // expected_deep_from_wallet
+        balance_manager_deep, // expected_deep_from_balance_manager
         deep_from_treasury, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -1182,6 +1200,7 @@ public fun ask_order_with_treasury_deep() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         deep_in_wallet, // expected_deep_from_wallet
+        balance_manager_deep, // expected_deep_from_balance_manager
         deep_from_treasury, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -1265,6 +1284,7 @@ public fun ask_order_coverage_fee_from_both_sources() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         deep_in_wallet, // expected_deep_from_wallet
+        balance_manager_deep, // expected_deep_from_balance_manager
         deep_from_treasury, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -1328,6 +1348,7 @@ public fun zero_quantity_order() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         0, // expected_deep_from_wallet
+        deep_required, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -1392,6 +1413,7 @@ public fun zero_price_order() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         0, // expected_deep_from_wallet
+        deep_required, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -1468,6 +1490,7 @@ public fun ask_order_input_coin_is_sui() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         0, // expected_deep_from_wallet
+        0, // expected_deep_from_balance_manager
         deep_from_reserves, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -1534,6 +1557,7 @@ public fun ask_order_input_coin_is_deep() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         0, // expected_deep_from_wallet
+        deep_required, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -1647,6 +1671,7 @@ public fun bid_order_sui_input_insufficient_wallet() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         0, // expected_deep_from_wallet
+        0, // expected_deep_from_balance_manager
         deep_from_reserves, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -1711,6 +1736,7 @@ public fun ask_order_deep_input_insufficient_wallet() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         0, // expected_deep_from_wallet
+        deep_required, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -1778,6 +1804,7 @@ public fun bid_order_sui_input_no_coverage_fee() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         deep_in_wallet, // expected_deep_from_wallet
+        balance_manager_deep, // expected_deep_from_balance_manager
         deep_from_reserves, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations
@@ -1841,6 +1868,7 @@ public fun ask_order_deep_input_whitelisted_pool() {
         input_coin_deposit_plan,
         // DeepPlan expectations
         0, // expected_deep_from_wallet
+        0, // expected_deep_from_balance_manager
         0, // expected_deep_from_reserves
         true, // expected_deep_sufficient
         // CoverageFeePlan expectations

--- a/packages/deeptrade-core/tests/core/create_order_core.move
+++ b/packages/deeptrade-core/tests/core/create_order_core.move
@@ -10,7 +10,8 @@ use deeptrade_core::order::{
     assert_input_coin_deposit_plan_eq,
     DeepPlan,
     CoverageFeePlan,
-    InputCoinDepositPlan
+    InputCoinDepositPlan,
+    EInvalidInputCoinType
 };
 use std::unit_test::assert_eq;
 
@@ -77,6 +78,8 @@ public fun bid_order_sufficient_resources() {
     let is_bid = true;
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances
     let deep_required = AMOUNT_SMALL;
@@ -110,6 +113,8 @@ public fun bid_order_sufficient_resources() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -138,6 +143,8 @@ public fun bid_order_with_treasury_deep() {
     let is_bid = true;
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances - not enough DEEP in wallet or balance manager
     let deep_required = AMOUNT_MEDIUM;
@@ -188,6 +195,8 @@ public fun bid_order_with_treasury_deep() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -216,6 +225,8 @@ public fun bid_order_whitelisted_pool() {
     let is_bid = true;
     let is_pool_whitelisted = true; // Whitelisted pool!
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances
     let deep_required = AMOUNT_SMALL;
@@ -249,6 +260,8 @@ public fun bid_order_whitelisted_pool() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -277,6 +290,8 @@ public fun bid_order_coverage_fee_from_both_sources() {
     let is_bid = true;
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances
     let deep_required = AMOUNT_MEDIUM;
@@ -322,6 +337,8 @@ public fun bid_order_coverage_fee_from_both_sources() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -350,6 +367,8 @@ public fun bid_order_insufficient_deep_no_treasury() {
     let is_bid = true;
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances - not enough DEEP anywhere
     let deep_required = AMOUNT_MEDIUM;
@@ -378,6 +397,8 @@ public fun bid_order_insufficient_deep_no_treasury() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -406,6 +427,8 @@ public fun bid_order_quote_only_in_balance_manager() {
     let is_bid = true;
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances - all resources in balance manager
     let deep_required = AMOUNT_SMALL;
@@ -434,6 +457,8 @@ public fun bid_order_quote_only_in_balance_manager() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -462,6 +487,8 @@ public fun bid_order_large_values() {
     let is_bid = true;
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Make sure we have enough resources for this large order
     let deep_required = AMOUNT_MEDIUM;
@@ -498,6 +525,8 @@ public fun bid_order_large_values() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -526,6 +555,8 @@ public fun bid_order_exact_resources() {
     let is_bid = true;
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances - exactly what's needed
     let deep_required = AMOUNT_SMALL;
@@ -554,6 +585,8 @@ public fun bid_order_exact_resources() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -584,6 +617,8 @@ public fun ask_order_sufficient_resources() {
     let is_bid = false; // Ask order
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances
     let deep_required = AMOUNT_SMALL;
@@ -619,6 +654,8 @@ public fun ask_order_sufficient_resources() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -647,6 +684,8 @@ public fun ask_order_whitelisted_pool() {
     let is_bid = false; // Ask order
     let is_pool_whitelisted = true; // Whitelisted pool!
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances
     let deep_required = AMOUNT_SMALL;
@@ -680,6 +719,8 @@ public fun ask_order_whitelisted_pool() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -708,6 +749,8 @@ public fun ask_order_insufficient_deep_and_base() {
     let is_bid = false; // Ask order
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances - not enough DEEP anywhere
     let deep_required = AMOUNT_MEDIUM;
@@ -736,6 +779,8 @@ public fun ask_order_insufficient_deep_and_base() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -764,6 +809,8 @@ public fun ask_order_base_only_in_balance_manager() {
     let is_bid = false; // Ask order
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances - base coins only in balance manager
     let deep_required = AMOUNT_SMALL;
@@ -800,6 +847,8 @@ public fun ask_order_base_only_in_balance_manager() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -828,6 +877,8 @@ public fun ask_order_large_values() {
     let is_bid = false; // Ask order
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Make sure we have enough resources for this large order
     let deep_required = AMOUNT_MEDIUM;
@@ -865,6 +916,8 @@ public fun ask_order_large_values() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -893,6 +946,8 @@ public fun ask_order_exact_resources() {
     let is_bid = false; // Ask order
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Set up resources to exactly match what's needed
     let deep_required = AMOUNT_SMALL;
@@ -921,6 +976,8 @@ public fun ask_order_exact_resources() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -949,6 +1006,8 @@ public fun ask_order_complex_distribution() {
     let is_bid = false; // Ask order
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances - split between wallet and balance manager
     let deep_required = AMOUNT_MEDIUM;
@@ -977,6 +1036,8 @@ public fun ask_order_complex_distribution() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -1005,6 +1066,8 @@ public fun ask_order_insufficient_base() {
     let is_bid = false; // Ask order
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances - not enough DEEP to force using treasury DEEP
     let deep_required = AMOUNT_MEDIUM;
@@ -1041,6 +1104,8 @@ public fun ask_order_insufficient_base() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -1069,6 +1134,8 @@ public fun ask_order_with_treasury_deep() {
     let is_bid = false; // Ask order
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances - not enough DEEP in wallet or balance manager
     let deep_required = AMOUNT_MEDIUM;
@@ -1105,6 +1172,8 @@ public fun ask_order_with_treasury_deep() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -1133,6 +1202,8 @@ public fun ask_order_coverage_fee_from_both_sources() {
     let is_bid = false; // Ask order
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances - not enough DEEP to avoid using treasury
     let deep_required = AMOUNT_MEDIUM;
@@ -1184,6 +1255,8 @@ public fun ask_order_coverage_fee_from_both_sources() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     assert_order_plans_eq(
@@ -1214,6 +1287,8 @@ public fun zero_quantity_order() {
     let is_bid = true;
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances
     let deep_required = AMOUNT_SMALL;
@@ -1242,6 +1317,8 @@ public fun zero_quantity_order() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     // For this test case, order amount should be zero
@@ -1271,6 +1348,8 @@ public fun zero_price_order() {
     let is_bid = true;
     let is_pool_whitelisted = false;
     let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = false;
 
     // Resource balances
     let deep_required = AMOUNT_SMALL;
@@ -1299,11 +1378,462 @@ public fun zero_price_order() {
         treasury_deep_reserves,
         order_amount,
         sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
     );
 
     // For bid orders with zero price, order amount should be zero
     let order_amount = calculate_order_amount(quantity, price, is_bid);
     assert_eq!(order_amount, 0);
+
+    assert_order_plans_eq(
+        deep_plan,
+        coverage_fee_plan,
+        input_coin_deposit_plan,
+        // DeepPlan expectations
+        0, // expected_deep_from_wallet
+        0, // expected_deep_from_reserves
+        true, // expected_deep_sufficient
+        // CoverageFeePlan expectations
+        0, // expected_coverage_fee_from_wallet
+        0, // expected_coverage_fee_from_balance_manager
+        true, // expected_user_covers_fee
+        // InputCoinDepositPlan expectations
+        0, // expected_deposit_from_wallet
+        true, // expected_deposit_sufficient
+    );
+}
+
+#[test]
+public fun ask_order_input_coin_is_sui() {
+    // Tests an ask order where the input coin is SUI.
+    // Verifies that when the balance manager has enough SUI to cover the order amount,
+    // a portion of it is first allocated to the coverage fee. The remaining balance
+    // is then used for the order amount, and the deficit is covered by the wallet.
+    // Order parameters
+    let quantity = 1_000_000_000;
+    let price = 1_000_000_000;
+    let is_bid = false;
+    let is_pool_whitelisted = false;
+    let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = true;
+    let input_coin_is_deep = false;
+
+    // Resource balances
+    let deep_required = AMOUNT_SMALL;
+    let balance_manager_deep = 0;
+    let balance_manager_sui = 1_000_000_000;
+    let balance_manager_input_coin = 1_000_000_000;
+
+    let deep_in_wallet = 0;
+    let sui_in_wallet = 0;
+    // Make wallet sufficient to cover the deficit
+    let wallet_input_coin = AMOUNT_LARGE;
+
+    let treasury_deep_reserves = AMOUNT_MEDIUM;
+
+    // Calculate expected values
+    let order_amount = calculate_order_amount(quantity, price, is_bid);
+
+    // Deep will be sourced from treasury, so a coverage fee is required
+    let deep_from_reserves = deep_required;
+    let coverage_fee = calculate_deep_reserves_coverage_order_fee(
+        sui_per_deep,
+        deep_from_reserves,
+    );
+
+    // The amount needed from the wallet is the order amount minus what's left
+    // in the balance manager after the coverage fee is paid.
+    let expected_deposit_from_wallet = order_amount - (balance_manager_input_coin - coverage_fee);
+
+    let (deep_plan, coverage_fee_plan, input_coin_deposit_plan) = create_order_core(
+        is_pool_whitelisted,
+        deep_required,
+        balance_manager_deep,
+        balance_manager_sui,
+        balance_manager_input_coin,
+        deep_in_wallet,
+        sui_in_wallet,
+        wallet_input_coin,
+        treasury_deep_reserves,
+        order_amount,
+        sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
+    );
+
+    assert_order_plans_eq(
+        deep_plan,
+        coverage_fee_plan,
+        input_coin_deposit_plan,
+        // DeepPlan expectations
+        0, // expected_deep_from_wallet
+        deep_from_reserves, // expected_deep_from_reserves
+        true, // expected_deep_sufficient
+        // CoverageFeePlan expectations
+        0, // expected_coverage_fee_from_wallet
+        coverage_fee, // expected_coverage_fee_from_balance_manager
+        true, // expected_user_covers_fee
+        // InputCoinDepositPlan expectations
+        expected_deposit_from_wallet, // expected_deposit_from_wallet
+        true, // expected_deposit_sufficient
+    );
+}
+
+#[test]
+public fun ask_order_input_coin_is_deep() {
+    // Tests an ask order where the input coin is DEEP.
+    // Verifies that DEEP from the balance manager is first used for the deep requirement,
+    // and the remainder is applied to the order amount. The wallet covers the rest.
+    // Order parameters
+    let quantity = 1_000_000_000;
+    let price = 1_000_000_000;
+    let is_bid = false;
+    let is_pool_whitelisted = false;
+    let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = true;
+
+    // Resource balances
+    let deep_required = AMOUNT_SMALL;
+    let balance_manager_deep = 1_000_000_000;
+    let balance_manager_sui = 0;
+    let balance_manager_input_coin = 1_000_000_000;
+
+    let deep_in_wallet = 0;
+    let sui_in_wallet = 0;
+    let wallet_input_coin = AMOUNT_MEDIUM;
+
+    let treasury_deep_reserves = AMOUNT_MEDIUM;
+
+    // Calculate expected values
+    let order_amount = calculate_order_amount(quantity, price, is_bid);
+    let deep_from_balance_manager = deep_required;
+    let expected_deposit_from_wallet =
+        order_amount - (balance_manager_deep - deep_from_balance_manager);
+
+    let (deep_plan, coverage_fee_plan, input_coin_deposit_plan) = create_order_core(
+        is_pool_whitelisted,
+        deep_required,
+        balance_manager_deep,
+        balance_manager_sui,
+        balance_manager_input_coin,
+        deep_in_wallet,
+        sui_in_wallet,
+        wallet_input_coin,
+        treasury_deep_reserves,
+        order_amount,
+        sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
+    );
+
+    assert_order_plans_eq(
+        deep_plan,
+        coverage_fee_plan,
+        input_coin_deposit_plan,
+        // DeepPlan expectations
+        0, // expected_deep_from_wallet
+        0, // expected_deep_from_reserves
+        true, // expected_deep_sufficient
+        // CoverageFeePlan expectations
+        0, // expected_coverage_fee_from_wallet
+        0, // expected_coverage_fee_from_balance_manager
+        true, // expected_user_covers_fee
+        // InputCoinDepositPlan expectations
+        expected_deposit_from_wallet, // expected_deposit_from_wallet
+        true, // expected_deposit_sufficient
+    );
+}
+
+#[test, expected_failure(abort_code = EInvalidInputCoinType)]
+public fun invalid_input_coin_flags() {
+    // Tests that create_order_core aborts if both input_coin_is_sui and
+    // input_coin_is_deep are true.
+    // Order parameters
+    let quantity = 1_000_000_000;
+    let price = 1_000_000_000;
+    let is_bid = false;
+    let is_pool_whitelisted = false;
+    let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = true;
+    let input_coin_is_deep = true;
+
+    // Resource balances (can be minimal since the function should abort early)
+    let deep_required = 0;
+    let balance_manager_deep = 0;
+    let balance_manager_sui = 0;
+    let balance_manager_input_coin = 0;
+    let deep_in_wallet = 0;
+    let sui_in_wallet = 0;
+    let wallet_input_coin = 0;
+    let treasury_deep_reserves = 0;
+    let order_amount = calculate_order_amount(quantity, price, is_bid);
+
+    create_order_core(
+        is_pool_whitelisted,
+        deep_required,
+        balance_manager_deep,
+        balance_manager_sui,
+        balance_manager_input_coin,
+        deep_in_wallet,
+        sui_in_wallet,
+        wallet_input_coin,
+        treasury_deep_reserves,
+        order_amount,
+        sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
+    );
+}
+
+#[test]
+public fun bid_order_sui_input_insufficient_wallet() {
+    // Tests a bid order where the input coin is SUI and the wallet has insufficient
+    // funds to cover the deposit after the balance manager pays the coverage fee.
+    // Order parameters
+    let quantity = 10_000_000;
+    let price = 1_000_000_000;
+    let is_bid = true;
+    let is_pool_whitelisted = false;
+    let sui_per_deep = 1_000_000_000; // 1 SUI per DEEP for simplicity
+    let input_coin_is_sui = true;
+    let input_coin_is_deep = false;
+
+    // Resource balances
+    let deep_required = 1_000_000;
+    let balance_manager_deep = 0;
+    let deep_in_wallet = 0;
+    let treasury_deep_reserves = AMOUNT_LARGE;
+
+    // Trigger coverage fee
+    let deep_from_reserves = deep_required;
+    let coverage_fee = calculate_deep_reserves_coverage_order_fee(
+        sui_per_deep,
+        deep_from_reserves,
+    ); // Should be 1,000,000
+
+    // BM can cover the fee, but not the whole order
+    let balance_manager_sui = 2_000_000;
+    let balance_manager_input_coin = balance_manager_sui;
+
+    let order_amount = calculate_order_amount(quantity, price, is_bid); // 10,000,000
+    let sui_left_in_bm = balance_manager_sui - coverage_fee; // 1,000,000
+    let deposit_needed_from_wallet = order_amount - sui_left_in_bm; // 9,000,000
+
+    // Wallet is insufficient
+    let wallet_input_coin = deposit_needed_from_wallet - 1; // 8,999,999
+    let sui_in_wallet = wallet_input_coin;
+
+    let (deep_plan, coverage_fee_plan, input_coin_deposit_plan) = create_order_core(
+        is_pool_whitelisted,
+        deep_required,
+        balance_manager_deep,
+        balance_manager_sui,
+        balance_manager_input_coin,
+        deep_in_wallet,
+        sui_in_wallet,
+        wallet_input_coin,
+        treasury_deep_reserves,
+        order_amount,
+        sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
+    );
+
+    assert_order_plans_eq(
+        deep_plan,
+        coverage_fee_plan,
+        input_coin_deposit_plan,
+        // DeepPlan expectations
+        0, // expected_deep_from_wallet
+        deep_from_reserves, // expected_deep_from_reserves
+        true, // expected_deep_sufficient
+        // CoverageFeePlan expectations
+        0, // expected_coverage_fee_from_wallet
+        coverage_fee, // expected_coverage_fee_from_balance_manager
+        true, // expected_user_covers_fee
+        // InputCoinDepositPlan expectations
+        0, // expected_deposit_from_wallet
+        false, // expected_deposit_sufficient
+    );
+}
+
+#[test]
+public fun ask_order_deep_input_insufficient_wallet() {
+    // Tests an ask order where the input coin is DEEP and the wallet has insufficient
+    // funds to cover the deposit after the balance manager pays the deep requirement.
+    // Order parameters
+    let quantity = 10_000_000;
+    let price = 1_000_000_000;
+    let is_bid = false;
+    let is_pool_whitelisted = false;
+    let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = true;
+
+    // Resource balances
+    let deep_required = 1_000_000;
+    // BM can cover the deep requirement, but not the whole order
+    let balance_manager_deep = 2_000_000;
+    let balance_manager_input_coin = balance_manager_deep;
+    let balance_manager_sui = 0;
+
+    let order_amount = calculate_order_amount(quantity, price, is_bid); // 10,000,000
+    let deep_left_in_bm = balance_manager_deep - deep_required; // 1,000,000
+    let deposit_needed_from_wallet = order_amount - deep_left_in_bm; // 9,000,000
+
+    // Wallet is insufficient
+    let wallet_input_coin = deposit_needed_from_wallet - 1; // 8,999,999
+    let deep_in_wallet = wallet_input_coin;
+    let sui_in_wallet = 0;
+    let treasury_deep_reserves = 0; // No treasury deep needed
+
+    let (deep_plan, coverage_fee_plan, input_coin_deposit_plan) = create_order_core(
+        is_pool_whitelisted,
+        deep_required,
+        balance_manager_deep,
+        balance_manager_sui,
+        balance_manager_input_coin,
+        deep_in_wallet,
+        sui_in_wallet,
+        wallet_input_coin,
+        treasury_deep_reserves,
+        order_amount,
+        sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
+    );
+
+    assert_order_plans_eq(
+        deep_plan,
+        coverage_fee_plan,
+        input_coin_deposit_plan,
+        // DeepPlan expectations
+        0, // expected_deep_from_wallet
+        0, // expected_deep_from_reserves
+        true, // expected_deep_sufficient
+        // CoverageFeePlan expectations
+        0, // expected_coverage_fee_from_wallet
+        0, // expected_coverage_fee_from_balance_manager
+        true, // expected_user_covers_fee
+        // InputCoinDepositPlan expectations
+        0, // expected_deposit_from_wallet
+        false, // expected_deposit_sufficient
+    );
+}
+
+#[test]
+public fun bid_order_sui_input_no_coverage_fee() {
+    // Tests that when input coin is SUI and no coverage fee is needed,
+    // the balance_manager_sui is not reduced for fees and is fully
+    // available for the order deposit.
+    // Order parameters
+    let quantity = 1_000_000;
+    let price = 1_000_000_000;
+    let is_bid = true;
+    let is_pool_whitelisted = false;
+    let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = true;
+    let input_coin_is_deep = false;
+
+    // Resource balances
+    // User has enough DEEP, so no treasury DEEP is needed
+    let deep_required = AMOUNT_SMALL;
+    let balance_manager_deep = AMOUNT_SMALL / 2;
+    let deep_in_wallet = AMOUNT_SMALL / 2;
+    let treasury_deep_reserves = AMOUNT_LARGE;
+
+    // No coverage fee will be generated
+    let deep_from_reserves = 0;
+    let coverage_fee = 0;
+
+    // BM has enough to cover the full order
+    let order_amount = calculate_order_amount(quantity, price, is_bid); // 1,000,000
+    let balance_manager_sui = order_amount;
+    let balance_manager_input_coin = balance_manager_sui;
+
+    let sui_in_wallet = 0;
+    let wallet_input_coin = 0;
+
+    let (deep_plan, coverage_fee_plan, input_coin_deposit_plan) = create_order_core(
+        is_pool_whitelisted,
+        deep_required,
+        balance_manager_deep,
+        balance_manager_sui,
+        balance_manager_input_coin,
+        deep_in_wallet,
+        sui_in_wallet,
+        wallet_input_coin,
+        treasury_deep_reserves,
+        order_amount,
+        sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
+    );
+
+    assert_order_plans_eq(
+        deep_plan,
+        coverage_fee_plan,
+        input_coin_deposit_plan,
+        // DeepPlan expectations
+        deep_in_wallet, // expected_deep_from_wallet
+        deep_from_reserves, // expected_deep_from_reserves
+        true, // expected_deep_sufficient
+        // CoverageFeePlan expectations
+        coverage_fee, // expected_coverage_fee_from_wallet
+        0, // expected_coverage_fee_from_balance_manager
+        true, // expected_user_covers_fee
+        // InputCoinDepositPlan expectations
+        0, // expected_deposit_from_wallet
+        true, // expected_deposit_sufficient
+    );
+}
+
+#[test]
+public fun ask_order_deep_input_whitelisted_pool() {
+    // Tests that when input coin is DEEP and the pool is whitelisted,
+    // the balance_manager_deep is not reduced for deep requirements and
+    // is fully available for the order deposit.
+    // Order parameters
+    let quantity = 1_000_000;
+    let price = 1_000_000_000;
+    let is_bid = false;
+    let is_pool_whitelisted = true; // Whitelisted pool
+    let sui_per_deep = SUI_PER_DEEP;
+    let input_coin_is_sui = false;
+    let input_coin_is_deep = true;
+
+    // Resource balances
+    // For a whitelisted pool, deep is not required.
+    let deep_required = AMOUNT_SMALL; // This will be ignored
+
+    // BM has enough to cover the full order
+    let order_amount = calculate_order_amount(quantity, price, is_bid); // 1,000,000
+    let balance_manager_deep = order_amount;
+    let balance_manager_input_coin = balance_manager_deep;
+    let balance_manager_sui = 0;
+
+    let deep_in_wallet = 0;
+    let sui_in_wallet = 0;
+    let wallet_input_coin = 0;
+    let treasury_deep_reserves = 0;
+
+    let (deep_plan, coverage_fee_plan, input_coin_deposit_plan) = create_order_core(
+        is_pool_whitelisted,
+        deep_required,
+        balance_manager_deep,
+        balance_manager_sui,
+        balance_manager_input_coin,
+        deep_in_wallet,
+        sui_in_wallet,
+        wallet_input_coin,
+        treasury_deep_reserves,
+        order_amount,
+        sui_per_deep,
+        input_coin_is_sui,
+        input_coin_is_deep,
+    );
 
     assert_order_plans_eq(
         deep_plan,

--- a/packages/deeptrade-core/tests/plans/execute_deep_plan_tests.move
+++ b/packages/deeptrade-core/tests/plans/execute_deep_plan_tests.move
@@ -68,6 +68,7 @@ fun deep_from_both_wallet_and_treasury_reserves() {
     assert_deep_plan_eq(
         deep_plan,
         expected_from_wallet,
+        balance_manager_deep,
         expected_from_treasury,
         true, // deep_reserves_cover_order
     );
@@ -172,6 +173,7 @@ fun insufficient_deep_reserves_aborts() {
     assert_deep_plan_eq(
         deep_plan,
         0, // from_user_wallet should be 0 when insufficient
+        0, // from_balance_manager should be 0 when insufficient
         0, // from_deep_reserves should be 0 when insufficient
         false, // deep_reserves_cover_order should be false
     );
@@ -256,6 +258,7 @@ fun deep_only_from_treasury_reserves() {
     assert_deep_plan_eq(
         deep_plan,
         expected_from_wallet,
+        balance_manager_deep,
         expected_from_treasury,
         true, // deep_reserves_cover_order
     );
@@ -361,6 +364,7 @@ fun deep_only_from_wallet() {
     assert_deep_plan_eq(
         deep_plan,
         expected_from_wallet,
+        balance_manager_deep,
         expected_from_treasury,
         true, // deep_reserves_cover_order
     );

--- a/packages/deeptrade-core/tests/plans/get_deep_plan.move
+++ b/packages/deeptrade-core/tests/plans/get_deep_plan.move
@@ -25,7 +25,7 @@ fun whitelisted_pools() {
         0, // wallet balance
         0, // treasury reserves
     );
-    assert_deep_plan_eq(plan, 0, 0, true);
+    assert_deep_plan_eq(plan, 0, 0, 0, true);
 
     // Test 2: Whitelisted pool with non-zero requirements (should still return zeros)
     let plan = get_deep_plan(
@@ -35,7 +35,7 @@ fun whitelisted_pools() {
         0, // wallet balance
         0, // treasury reserves
     );
-    assert_deep_plan_eq(plan, 0, 0, true);
+    assert_deep_plan_eq(plan, 0, 0, 0, true);
 
     // Test 3: Whitelisted pool with available DEEP (should ignore available DEEP)
     let plan = get_deep_plan(
@@ -45,7 +45,7 @@ fun whitelisted_pools() {
         DEEP_SMALL, // some in wallet
         DEEP_HUGE, // large treasury reserves
     );
-    assert_deep_plan_eq(plan, 0, 0, true);
+    assert_deep_plan_eq(plan, 0, 0, 0, true);
 }
 
 // -------------------------------------
@@ -63,7 +63,7 @@ fun user_has_sufficient_deep_all_in_manager() {
         0, // nothing in wallet
         0, // treasury reserves (unused)
     );
-    assert_deep_plan_eq(plan, 0, 0, true);
+    assert_deep_plan_eq(plan, 0, required, 0, true);
 
     // Excess DEEP in manager
     let plan = get_deep_plan(
@@ -73,7 +73,7 @@ fun user_has_sufficient_deep_all_in_manager() {
         0, // nothing in wallet
         0, // treasury reserves (unused)
     );
-    assert_deep_plan_eq(plan, 0, 0, true);
+    assert_deep_plan_eq(plan, 0, required, 0, true);
 }
 
 #[test]
@@ -87,7 +87,7 @@ fun user_has_sufficient_deep_all_in_wallet() {
         required, // exact amount in wallet
         0, // treasury reserves (unused)
     );
-    assert_deep_plan_eq(plan, required, 0, true);
+    assert_deep_plan_eq(plan, required, 0, 0, true);
 
     // Excess DEEP in wallet
     let plan = get_deep_plan(
@@ -97,7 +97,7 @@ fun user_has_sufficient_deep_all_in_wallet() {
         required * 2, // excess in wallet
         0, // treasury reserves (unused)
     );
-    assert_deep_plan_eq(plan, required, 0, true);
+    assert_deep_plan_eq(plan, required, 0, 0, true);
 }
 
 #[test]
@@ -114,7 +114,7 @@ fun user_has_sufficient_deep_split() {
         wallet_amount, // rest in wallet
         0, // treasury reserves (unused)
     );
-    assert_deep_plan_eq(plan, wallet_amount, 0, true);
+    assert_deep_plan_eq(plan, wallet_amount, manager_amount, 0, true);
 
     // DEEP split with excess in both
     let plan = get_deep_plan(
@@ -125,7 +125,7 @@ fun user_has_sufficient_deep_split() {
         0, // treasury reserves (unused)
     );
     // Should only take what's needed from wallet
-    assert_deep_plan_eq(plan, required - manager_amount * 2, 0, true);
+    assert_deep_plan_eq(plan, required - (manager_amount * 2), manager_amount * 2, 0, true);
 }
 
 #[test]
@@ -139,7 +139,7 @@ fun user_has_more_deep_in_manager_than_required() {
         DEEP_SMALL, // small amount in wallet
         0, // treasury reserves (unused)
     );
-    assert_deep_plan_eq(plan, 0, 0, true);
+    assert_deep_plan_eq(plan, 0, required, 0, true);
 }
 
 // -------------------------------------
@@ -160,7 +160,7 @@ fun user_needs_partial_treasury_deep() {
         user_deep, // some in wallet
         required, // sufficient treasury reserves
     );
-    assert_deep_plan_eq(plan, user_deep, treasury_needed, true);
+    assert_deep_plan_eq(plan, user_deep, 0, treasury_needed, true);
 
     // Split user DEEP between manager and wallet
     let manager_deep = user_deep / 2;
@@ -173,7 +173,7 @@ fun user_needs_partial_treasury_deep() {
         wallet_deep, // some in wallet
         required, // sufficient treasury reserves
     );
-    assert_deep_plan_eq(plan, wallet_deep, treasury_needed, true);
+    assert_deep_plan_eq(plan, wallet_deep, manager_deep, treasury_needed, true);
 }
 
 #[test]
@@ -188,7 +188,7 @@ fun user_needs_all_treasury_deep() {
         0, // nothing in wallet
         required, // exact treasury reserves
     );
-    assert_deep_plan_eq(plan, 0, required, true);
+    assert_deep_plan_eq(plan, 0, 0, required, true);
 
     // No user DEEP, treasury has excess
     let plan = get_deep_plan(
@@ -198,7 +198,7 @@ fun user_needs_all_treasury_deep() {
         0, // nothing in wallet
         required * 2, // excess treasury reserves
     );
-    assert_deep_plan_eq(plan, 0, required, true);
+    assert_deep_plan_eq(plan, 0, 0, required, true);
 }
 
 #[test]
@@ -215,7 +215,7 @@ fun treasury_exact_remainder() {
         user_deep, // some in wallet
         treasury_needed, // exact treasury reserves needed
     );
-    assert_deep_plan_eq(plan, user_deep, treasury_needed, true);
+    assert_deep_plan_eq(plan, user_deep, 0, treasury_needed, true);
 }
 
 // -------------------------------------
@@ -237,7 +237,7 @@ fun insufficient_treasury_reserves() {
         user_deep, // some in wallet
         insufficient_reserves, // insufficient treasury reserves
     );
-    assert_deep_plan_eq(plan, 0, 0, false);
+    assert_deep_plan_eq(plan, 0, 0, 0, false);
 
     // Almost nothing in treasury
     let plan = get_deep_plan(
@@ -247,7 +247,7 @@ fun insufficient_treasury_reserves() {
         user_deep, // some in wallet
         1, // just 1 token in treasury
     );
-    assert_deep_plan_eq(plan, 0, 0, false);
+    assert_deep_plan_eq(plan, 0, 0, 0, false);
 }
 
 #[test]
@@ -262,7 +262,7 @@ fun no_deep_anywhere() {
         0, // nothing in wallet
         0, // no treasury reserves
     );
-    assert_deep_plan_eq(plan, 0, 0, false);
+    assert_deep_plan_eq(plan, 0, 0, 0, false);
 
     // Small amount in user, none in treasury
     let small_amount = required / 10;
@@ -273,7 +273,7 @@ fun no_deep_anywhere() {
         0, // nothing in wallet
         0, // no treasury reserves
     );
-    assert_deep_plan_eq(plan, 0, 0, false);
+    assert_deep_plan_eq(plan, 0, 0, 0, false);
 }
 
 // -------------------------------------
@@ -290,7 +290,7 @@ fun zero_deep_required() {
         0, // wallet balance
         0, // treasury reserves
     );
-    assert_deep_plan_eq(plan, 0, 0, true);
+    assert_deep_plan_eq(plan, 0, 0, 0, true);
 
     // Zero DEEP required but DEEP available
     let plan = get_deep_plan(
@@ -300,7 +300,7 @@ fun zero_deep_required() {
         DEEP_SMALL, // some in wallet
         DEEP_SMALL, // some in treasury
     );
-    assert_deep_plan_eq(plan, 0, 0, true);
+    assert_deep_plan_eq(plan, 0, 0, 0, true);
 }
 
 #[test]
@@ -316,7 +316,7 @@ fun large_values() {
         0, // wallet balance
         0, // treasury reserves
     );
-    assert_deep_plan_eq(plan, 0, 0, true);
+    assert_deep_plan_eq(plan, 0, large_value, 0, true);
 
     // Large requirement with matching wallet balance
     let plan = get_deep_plan(
@@ -326,7 +326,7 @@ fun large_values() {
         large_value, // matching wallet balance
         0, // treasury reserves
     );
-    assert_deep_plan_eq(plan, large_value, 0, true);
+    assert_deep_plan_eq(plan, large_value, 0, 0, true);
 
     // Large requirement with matching treasury reserves
     let plan = get_deep_plan(
@@ -336,7 +336,7 @@ fun large_values() {
         0, // wallet balance
         large_value, // matching treasury reserves
     );
-    assert_deep_plan_eq(plan, 0, large_value, true);
+    assert_deep_plan_eq(plan, 0, 0, large_value, true);
 }
 
 // -------------------------------------
@@ -356,7 +356,7 @@ fun exact_balance_boundaries() {
         0, // nothing in wallet
         0, // no treasury reserves
     );
-    assert_deep_plan_eq(plan, 0, 0, true);
+    assert_deep_plan_eq(plan, 0, required, 0, true);
 
     // Wallet exactly matches required
     let plan = get_deep_plan(
@@ -366,7 +366,7 @@ fun exact_balance_boundaries() {
         required, // exact amount in wallet
         0, // no treasury reserves
     );
-    assert_deep_plan_eq(plan, required, 0, true);
+    assert_deep_plan_eq(plan, required, 0, 0, true);
 
     // Combined user balance equals exactly required
     let manager_amount = required / 2;
@@ -378,7 +378,7 @@ fun exact_balance_boundaries() {
         wallet_amount, // rest in wallet
         0, // no treasury reserves
     );
-    assert_deep_plan_eq(plan, wallet_amount, 0, true);
+    assert_deep_plan_eq(plan, wallet_amount, manager_amount, 0, true);
 
     // Treasury exactly matches what's needed
     let user_amount = required / 2;
@@ -390,7 +390,7 @@ fun exact_balance_boundaries() {
         user_amount, // some in wallet
         treasury_needed, // exact treasury reserves needed
     );
-    assert_deep_plan_eq(plan, user_amount, treasury_needed, true);
+    assert_deep_plan_eq(plan, user_amount, 0, treasury_needed, true);
 }
 
 #[test]
@@ -406,7 +406,7 @@ fun one_token_boundaries() {
         0, // nothing in wallet
         0, // no treasury reserves
     );
-    assert_deep_plan_eq(plan, 0, 0, false);
+    assert_deep_plan_eq(plan, 0, 0, 0, false);
 
     // One token in wallet completes the requirement
     let plan = get_deep_plan(
@@ -416,7 +416,7 @@ fun one_token_boundaries() {
         1, // one token in wallet
         0, // no treasury reserves
     );
-    assert_deep_plan_eq(plan, 1, 0, true);
+    assert_deep_plan_eq(plan, 1, required - 1, 0, true);
 
     // One token short with treasury
     let user_amount = required / 2;
@@ -428,7 +428,7 @@ fun one_token_boundaries() {
         user_amount, // some in wallet
         treasury_needed - 1, // one token short in treasury
     );
-    assert_deep_plan_eq(plan, 0, 0, false);
+    assert_deep_plan_eq(plan, 0, 0, 0, false);
 
     // One extra token in treasury
     let plan = get_deep_plan(
@@ -438,5 +438,5 @@ fun one_token_boundaries() {
         user_amount, // some in wallet
         treasury_needed + 1, // one token extra in treasury
     );
-    assert_deep_plan_eq(plan, user_amount, treasury_needed, true);
+    assert_deep_plan_eq(plan, user_amount, 0, treasury_needed, true);
 }


### PR DESCRIPTION
## The Bug: What Was Wrong?
When a user placed an order where the input coin was SUI or DEEP, our code would attempt to use the same funds for both the order amount and its associated fees. This "double-counting" meant we didn't actually have enough money to cover both, causing the transaction to fail.

## A Real-World Example
Here’s a simple scenario where this bug would occur:
1. A user has exactly **1 SUI** in their Balance Manager.
2. They place a sell order for that **1 SUI**.
3. Since they have no DEEP tokens, they must pay a coverage fee of **0.001 SUI**.
4. The system would see the 1 SUI balance and approve both actions: taking 0.001 SUI for the fee and 1 SUI for the order.
5. During execution, the fee is paid first, leaving only **0.999 SUI** in the balance.
6. The system then tries to submit the 1 SUI order to Deepbook, but with only 0.999 SUI available.
7. Deepbook correctly rejects this, causing the entire transaction to fail with an `EBalanceManagerBalanceTooLow` error.

## How We Fixed It
The fix is simple: we now subtract any fees from the user's balance _before_ we calculate the amount available for the trade. This ensures we only use funds that are actually available.

## How We Know It's Fixed
We added a new test, `sell_order_from_balance_manager`, that perfectly recreates this failure. The test now passes. Before this fix, running the same test on the old code would cause it to predictably fail with an `EBalanceManagerBalanceTooLow` error from Deepbook.