### PR TITLE
Feature/replace deprecated type_name function

### DIFF
--- a/.github/workflows/move_test.yml
+++ b/.github/workflows/move_test.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      SUI_VERSION: "1.54.2" # Parameterized Sui version
+      SUI_VERSION: "1.56.1" # Parameterized Sui version
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/move_test.yml
+++ b/.github/workflows/move_test.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      SUI_VERSION: "1.55.0" # Parameterized Sui version
+      SUI_VERSION: "1.56.2" # Parameterized Sui version
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/move_test.yml
+++ b/.github/workflows/move_test.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      SUI_VERSION: "1.56.1" # Parameterized Sui version
+      SUI_VERSION: "1.56.2" # Parameterized Sui version
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/move_test.yml
+++ b/.github/workflows/move_test.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      SUI_VERSION: "1.56.2" # Parameterized Sui version
+      SUI_VERSION: "1.55.0" # Parameterized Sui version
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/deeptrade-core/Move.lock
+++ b/packages/deeptrade-core/Move.lock
@@ -16,7 +16,7 @@ dependencies = [
 
 [[move.package]]
 id = "Bridge"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "b448b1d971bd6c1aac8ef4eee4305943806d5d5b", subdir = "crates/sui-framework/packages/bridge" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "664b05b3b047c5bb03979d093660176176ea6175", subdir = "crates/sui-framework/packages/bridge" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -26,7 +26,7 @@ dependencies = [
 
 [[move.package]]
 id = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "b448b1d971bd6c1aac8ef4eee4305943806d5d5b", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "664b05b3b047c5bb03979d093660176176ea6175", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 id = "Pyth"
@@ -39,7 +39,7 @@ dependencies = [
 
 [[move.package]]
 id = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "b448b1d971bd6c1aac8ef4eee4305943806d5d5b", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "664b05b3b047c5bb03979d093660176176ea6175", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -47,7 +47,7 @@ dependencies = [
 
 [[move.package]]
 id = "SuiSystem"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "b448b1d971bd6c1aac8ef4eee4305943806d5d5b", subdir = "crates/sui-framework/packages/sui-system" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "664b05b3b047c5bb03979d093660176176ea6175", subdir = "crates/sui-framework/packages/sui-system" }
 
 dependencies = [
   { id = "MoveStdlib", name = "MoveStdlib" },
@@ -91,7 +91,7 @@ dependencies = [
 ]
 
 [move.toolchain-version]
-compiler-version = "1.53.2"
+compiler-version = "1.56.2"
 edition = "2024.beta"
 flavor = "sui"
 

--- a/packages/deeptrade-core/sources/helper.move
+++ b/packages/deeptrade-core/sources/helper.move
@@ -219,10 +219,10 @@ public(package) fun get_sui_per_deep_from_reference_pool<ReferenceBaseAsset, Ref
     );
     let reference_pool_price = get_pool_first_ask_price(reference_pool, clock);
 
-    let reference_base_type = type_name::get<ReferenceBaseAsset>();
-    let reference_quote_type = type_name::get<ReferenceQuoteAsset>();
-    let deep_type = type_name::get<DEEP>();
-    let sui_type = type_name::get<SUI>();
+    let reference_base_type = type_name::with_original_ids<ReferenceBaseAsset>();
+    let reference_quote_type = type_name::with_original_ids<ReferenceQuoteAsset>();
+    let deep_type = type_name::with_original_ids<DEEP>();
+    let sui_type = type_name::with_original_ids<SUI>();
     let is_deep_sui_pool = reference_base_type == deep_type && reference_quote_type == sui_type;
     let is_sui_deep_pool = reference_base_type == sui_type && reference_quote_type == deep_type;
 

--- a/packages/deeptrade-core/sources/order.move
+++ b/packages/deeptrade-core/sources/order.move
@@ -1430,10 +1430,12 @@ public(package) fun prepare_order_execution<
         .max_deep_fee_coverage_discount_rate();
 
     // Determine input coin type
-    let input_coin_is_sui = if (is_bid) type_name::get<QuoteToken>() == type_name::get<SUI>()
-    else type_name::get<BaseToken>() == type_name::get<SUI>();
-    let input_coin_is_deep = if (is_bid) type_name::get<QuoteToken>() == type_name::get<DEEP>()
-    else type_name::get<BaseToken>() == type_name::get<DEEP>();
+    let input_coin_is_sui = if (is_bid)
+        type_name::with_original_ids<QuoteToken>() == type_name::with_original_ids<SUI>()
+    else type_name::with_original_ids<BaseToken>() == type_name::with_original_ids<SUI>();
+    let input_coin_is_deep = if (is_bid)
+        type_name::with_original_ids<QuoteToken>() == type_name::with_original_ids<DEEP>()
+    else type_name::with_original_ids<BaseToken>() == type_name::with_original_ids<DEEP>();
 
     let (deep_plan, coverage_fee_plan, input_coin_deposit_plan) = create_order_core(
         is_pool_whitelisted,


### PR DESCRIPTION
Replace deprecated `type_name::get` function usage with `type_name::with_original_ids`.

More details:
https://github.com/MystenLabs/sui/blob/mainnet-v1.56.2/external-crates/move/crates/move-stdlib/sources/type_name.move#L135