### PR TITLE
fix move ci path filter on push so it matches pull requests

### DIFF
--- a/.github/workflows/move_test.yml
+++ b/.github/workflows/move_test.yml
@@ -10,7 +10,9 @@ on:
       - main
     paths:
       - ".github/workflows/move_test.yml"
-      - "packages/deeptrade-core/**.move"
+      # Match pull_request: dependency/manifest changes must run build + test on main,
+      # not only *.move files (Move.toml / Move.lock / mvr.config.json were previously skipped).
+      - "packages/deeptrade-core/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## what changed

The `push` trigger for `Move Test CI` only watched `packages/deeptrade-core/**.move`, while `pull_request` watched the whole `packages/deeptrade-core/**` tree. A direct push to `main` that only changed `Move.toml`, `Move.lock`, or other non-`.move` files could skip `sui move build` and `sui move test` even though those files affect resolution and builds.

This aligns the `push.paths` filter with `pull_request` so dependency and manifest edits on `main` get the same CI coverage as PRs.

---

made by mooncitydev